### PR TITLE
changed e-mail parameter to not require e-mail

### DIFF
--- a/scripts/orchestration/getCertForElb.sh
+++ b/scripts/orchestration/getCertForElb.sh
@@ -2,7 +2,7 @@
 dsmFqdn=${1}
 curl -O https://dl.eff.org/certbot-auto
 chmod a+x certbot-auto
-./certbot-auto --debug certonly --webroot -w /usr/share/nginx/html/ -d ${dsmFqdn} --non-interactive --agree-tos --email event@trenddemos.com
+./certbot-auto --debug certonly --webroot -w /usr/share/nginx/html/ -d ${dsmFqdn} --non-interactive --agree-tos --register-unsafely-without-email
 sudo chown -R ec2-user:ec2-user /etc/letsencrypt
 aws iam delete-server-certificate --server-certificate-name ${dsmFqdn}
 uploadResponse=$(aws iam upload-server-certificate --server-certificate-name ${dsmFqdn} --certificate-body file:///etc/letsencrypt/archive/${dsmFqdn}/cert1.pem --private-key file:///etc/letsencrypt/archive/${dsmFqdn}/privkey1.pem)


### PR DESCRIPTION
the unsafely-register parameter prevents CA from sending renewal reminder.  Since we aren't using these certs for 90 days, this should cause no issue.  