### PR TITLE
fixed AMIs for w7 comp

### DIFF
--- a/cfn/officescan.template
+++ b/cfn/officescan.template
@@ -53,12 +53,12 @@
     "AMIs" : {
       "us-east-1" : {
         "cleanW7" : "ami-48d9345e",
-        "compW7" : "ami-302bd626",
+        "compW7" : "ami-141fe302",
         "osceServer" : "ami-45e3ec52"
       },
       "ap-northeast-1" : {
         "cleanW7" : "ami-2e450049",
-        "compW7"   : "ami-8d2f6bea",
+        "compW7"   : "ami-98a9edff",
         "osceServer" : "ami-6bee800c"
       }
     }


### PR DESCRIPTION
previous AMI was set to para instead of HVM which is needed for c4.large