### PR TITLE
Update AMIs for W7-Compromized

### DIFF
--- a/cfn/officescan.template
+++ b/cfn/officescan.template
@@ -53,12 +53,12 @@
     "AMIs" : {
       "us-east-1" : {
         "cleanW7" : "ami-48d9345e",
-        "compW7" : "ami-302bd626",
+        "compW7" : "ami-141fe302",
         "osceServer" : "ami-45e3ec52"
       },
       "ap-northeast-1" : {
         "cleanW7" : "ami-2e450049",
-        "compW7"   : "ami-8d2f6bea",
+        "compW7"   : "ami-98a9edff",
         "osceServer" : "ami-6bee800c"
       }
     }


### PR DESCRIPTION
Changed AMI type from paravirtual to HVM to support c4.large type