### PR TITLE
Fixed SSL Issuance problem 

### DIFF
--- a/cfn/tcSharedServices.template
+++ b/cfn/tcSharedServices.template
@@ -169,6 +169,12 @@
           },
           {
             "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "tcp",
             "FromPort" : "22",
             "ToPort" : "22",
             "SourceSecurityGroupId" : { "Ref": "ControllerSecurityGroup" }


### PR DESCRIPTION
Opened port 80 inbound to CTF for new domain validation challenge

Issue Reference: https://community.letsencrypt.org/t/important-what-you-need-to-know-about-tls-sni-validation-issues/50811