### PR TITLE
Switch to CTF AMI instead of install + Add Sydney Region

### DIFF
--- a/cfn/tcSharedServices.template
+++ b/cfn/tcSharedServices.template
@@ -4,7 +4,7 @@
   "Parameters" : {
     "BaseUrl" : {
       "Type" : "String",
-      "Default" : "https://s3.amazonaws.com/trendctf/cfn/"
+      "Default" : "https://s3.amazonaws.com/trendctf-staging/cfn/"
     },
     "AWSIKeyPairName" : {
       "Type" : "AWS::EC2::KeyPair::KeyName"

--- a/cfn/tcSharedServices.template
+++ b/cfn/tcSharedServices.template
@@ -48,7 +48,7 @@
   "Mappings" : {
     "AMIs" : {
       "us-east-1" : {
-        "ctf" : "ami-49c9295f",
+        "ctf" : "ami-88dcd7f3",
         "ctrl" : "ami-9be6f38c"
       },
       "us-west-1" : {
@@ -317,7 +317,7 @@
                 { "Fn::Sub" : [ "echo ${t0AdminPassword} > /home/ubuntu/variables/t0AdminPassword\n", { "t0AdminPassword": { "Ref": "DsmT0Password" } } ] },
                 { "Fn::Sub" : [ "echo ${eventName} > /home/ubuntu/variables/eventName\n", { "eventName": { "Ref": "EventName" } } ] },
                 { "Fn::Sub" : [ "echo ${baseDomain} > /home/ubuntu/variables/baseDomain\n", { "baseDomain": { "Ref": "baseDomain" } } ] },
-                "curl https://raw.githubusercontent.com/424D57/tmThreatChallenge/master/scripts/orchestration/setupCtfInstance.sh -o /home/ubuntu/setupCtfInstance.sh\n",
+                "curl https://raw.githubusercontent.com/wisco24/tmThreatChallenge/master/scripts/orchestration/setupCtfInstance.sh -o /home/ubuntu/setupCtfInstance.sh\n",
                 "cd /home/ubuntu/; chmod +x ./setupCtfInstance.sh; ./setupCtfInstance.sh\n"
               ]
             ]

--- a/cfn/tcSharedServices.template
+++ b/cfn/tcSharedServices.template
@@ -4,7 +4,7 @@
   "Parameters" : {
     "BaseUrl" : {
       "Type" : "String",
-      "Default" : "https://s3.amazonaws.com/trendctf-staging/cfn/"
+      "Default" : "https://s3.amazonaws.com/trendctf/cfn/"
     },
     "AWSIKeyPairName" : {
       "Type" : "AWS::EC2::KeyPair::KeyName"

--- a/cfn/tcSharedServices.template
+++ b/cfn/tcSharedServices.template
@@ -62,6 +62,10 @@
       "eu-central-1" : {
         "ctf" : "ami-78559817",
         "ctrl"   : "ami-5b06d634"
+      },
+      "ap-southeast-2" : {
+        "ctf" : "ami-c625dda4",
+        "ctrl"   : "ami-942dd1f6"
       }
     },
     "Parameters" : {

--- a/cfn/tcSharedServices.template
+++ b/cfn/tcSharedServices.template
@@ -327,7 +327,7 @@
                 { "Fn::Sub" : [ "echo ${t0AdminPassword} > /home/ubuntu/variables/t0AdminPassword\n", { "t0AdminPassword": { "Ref": "DsmT0Password" } } ] },
                 { "Fn::Sub" : [ "echo ${eventName} > /home/ubuntu/variables/eventName\n", { "eventName": { "Ref": "EventName" } } ] },
                 { "Fn::Sub" : [ "echo ${baseDomain} > /home/ubuntu/variables/baseDomain\n", { "baseDomain": { "Ref": "baseDomain" } } ] },
-                "curl https://raw.githubusercontent.com/wisco24/tmThreatChallenge/master/scripts/orchestration/setupCtfInstance.sh -o /home/ubuntu/setupCtfInstance.sh\n",
+                "curl https://raw.githubusercontent.com/424D57/tmThreatChallenge/master/scripts/orchestration/setupCtfInstance.sh -o /home/ubuntu/setupCtfInstance.sh\n",
                 "cd /home/ubuntu/; chmod +x ./setupCtfInstance.sh; ./setupCtfInstance.sh\n"
               ]
             ]

--- a/cfn/tcSharedServices.template
+++ b/cfn/tcSharedServices.template
@@ -169,6 +169,12 @@
           },
           {
             "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "tcp",
             "FromPort" : "22",
             "ToPort" : "22",
             "SourceSecurityGroupId" : { "Ref": "ControllerSecurityGroup" }

--- a/cfn/tcSharedServices.template
+++ b/cfn/tcSharedServices.template
@@ -48,7 +48,7 @@
   "Mappings" : {
     "AMIs" : {
       "us-east-1" : {
-        "ctf" : "ami-88dcd7f3",
+        "ctf" : "ami-aeb486d4",
         "ctrl" : "ami-9be6f38c"
       },
       "us-west-1" : {
@@ -165,6 +165,12 @@
             "IpProtocol": "tcp",
             "FromPort": "443",
             "ToPort": "443",
+            "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
             "CidrIp": "0.0.0.0/0"
           },
           {

--- a/cfn/teamInstancesDsAtk.template
+++ b/cfn/teamInstancesDsAtk.template
@@ -93,6 +93,11 @@
         "hackvtm" : "ami-f5d4069a",
         "jump"   : "ami-59d80a36",
         "msf" : "ami-1ad50775"
+      },
+      "ap-southeast-2" : {
+        "hackvtm" : "ami-18b87e7a",
+        "jump"   : "ami-1bb87e79",
+        "msf" : "ami-57c60035"
       }
     }
   },

--- a/cfn/teamInstancesDsDef.template
+++ b/cfn/teamInstancesDsDef.template
@@ -98,7 +98,7 @@
       },
       "ap-southeast-2" : {
         "atk" : "ami-54c60036",
-        "defvtm"   : "ami-54c60036"
+        "defvtm"   : "ami-4ac60028"
       }
     }
   },

--- a/cfn/teamInstancesDsDef.template
+++ b/cfn/teamInstancesDsDef.template
@@ -95,6 +95,10 @@
       "eu-central-1" : {
         "atk" : "ami-38da0857",
         "defvtm"   : "ami-f7d50798"
+      },
+      "ap-southeast-2" : {
+        "atk" : "ami-54c60036",
+        "defvtm"   : "ami-54c60036"
       }
     }
   },

--- a/scripts/orchestration/setupCtfInstance.sh
+++ b/scripts/orchestration/setupCtfInstance.sh
@@ -7,4 +7,5 @@ eventName=$(cat /home/ubuntu/variables/eventName)
 chown -R ubuntu:ubuntu fbctf
 cd /home/ubuntu/fbctf
 export HOME=/root
+chmod +x /extra/certupdate.sh
 ./extra/certupdate.sh admin@${baseDomain} ctf.${eventName}.${baseDomain} ${dsmT0Password}

--- a/scripts/orchestration/setupCtfInstance.sh
+++ b/scripts/orchestration/setupCtfInstance.sh
@@ -4,5 +4,7 @@ dsmT0Password=$(cat /home/ubuntu/variables/t0AdminPassword)
 baseDomain=$(cat /home/ubuntu/variables/baseDomain)
 eventName=$(cat /home/ubuntu/variables/eventName)
 
+chown -R ubuntu:ubuntu fbctf
 cd /home/ubuntu/fbctf
+export HOME=/root
 ./extra/certupdate.sh admin@${baseDomain} ctf.${eventName}.${baseDomain} ${dsmT0Password}

--- a/scripts/orchestration/setupCtfInstance.sh
+++ b/scripts/orchestration/setupCtfInstance.sh
@@ -4,13 +4,5 @@ dsmT0Password=$(cat /home/ubuntu/variables/t0AdminPassword)
 baseDomain=$(cat /home/ubuntu/variables/baseDomain)
 eventName=$(cat /home/ubuntu/variables/eventName)
 
-cd /home/ubuntu/
-apt-get update
-apt-get -y install git
-git clone https://github.com/wisco24/fbctf.git fbctf
-chown -R ubuntu:ubuntu fbctf
-cd fbctf
-export HOME=/root
-./extra/provision.sh -m prod -c certbot -D ctf.${eventName}.${baseDomain} -e admin@${baseDomain} -s $PWD
-source ./extra/lib.sh
-set_password ${dsmT0Password} ctf ctf fbctf $PWD
+cd /home/ubuntu/fbctf
+./extra/certupdate.sh admin@${baseDomain} ctf.${eventName}.${baseDomain} ${dsmT0Password}


### PR DESCRIPTION
Switched the CTF to an AMI for all regions.  Updated the "Setup CTF" code to update the cert to the correct domain.   Also opened port 80 due to Let's Encrpyt vulnerability.   Finally Added support for AP-Southeast region (Sydney) at request of ANZ team.  